### PR TITLE
Create tree index

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,22 @@ This repository contains the results of an analysis of available testing framewo
 
 Specifically, we are interested in the following questions:
 - What are the available testing frameworks for Tydi-Chisel?
-- What are the advantages and disadvantages of each framework?
+- What are the advantages and disadvantages of each framework?.
+
+- [A collection of Chisel and Tydi-Chisel examples that support the analysis of the frameworks](examples)
+  - [Chisel examples](examples/chisel-examples): a list of examples of Chisel designs
+    - [README.md](examples/chisel-examples/README.md): description of the examples
+    - [src/main](examples/chisel-examples/src/main): source code of Chisel examples
+    - [src/test](examples/chisel-examples/src/chiseltest): testbenches of Chisel examples
+  - [Tydi-Chisel code examples](examples/tydi-chisel-examples): a list of examples of Tydi-Chisel designs
+    - [README.md](examples/tydi-chisel-examples/README.md): description of the examples
+    - [tydi](examples/tydi-chisel-examples/tydi): source tydi code of Tydi-Chisel examples
+    - [chisel](examples/tydi-chisel-examples/chisel)  
+      - [src/main](examples/tydi-chisel-examples/chisel/src/main): source code of Tydi-Chisel examples
+      - [src/test](examples/tydi-chisel-examples/chisel/src/test): testbenches of Tydi-Chisel examples
+- [Tool analysis results](results): outcomes of the analysis
+  - [An analysis of the features of chiseltest: a testing framework for Chisel and Chisel-related projects](results/chiseltest)
+  - [hgdb](results/hgdb): analysis of hgdb debugger
+  - [An analysis of the waveforms produced by Chisel testbenches](results/waveforms)
+  - [A detailed analysis of Tydi-Chisel representations in testing frameworks](results/analysis-by-example)ù
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+# A collection of Chisel and Tydi-Chisel examples that support the analysis of the frameworks
+This folder contains several examples of Chisel and Tydi-Chisel designs. 
+The examples are used to support the analysis that is object of this repository. 
+They are used to test the features of the testing frameworks and highlight eventual limitations.
+
+The examples are divided into two folders: [chisel-examples](chisel-examples) and [tydi-chisel-examples](tydi-chisel-examples). The [chisel-examples](chisel-examples) contains sources of Chisel designs. The [tydi-chisel-examples](tydi-chisel-examples) folder contains Tydi-Chisel implementations. 
+
+> **Note:** Each subfolder contains a readme in which the examples are detailed.

--- a/examples/chisel-examples/README.md
+++ b/examples/chisel-examples/README.md
@@ -6,19 +6,19 @@ The primary objective of these modifications is to highlight certain characteris
 might remain obscured while using the available testing frameworks.
 
 Specifically, the following examples have been selected:
-- [`Adder`](./src/main/Adder.scala): A simple N-bit adder circuit, that uses `Array` (scala) class to wrap the 
-    [`FullAdder`](./src/main/FullAdder.scala)s modules, `Vec` and `Bundle` (chisel) to group together signals needed for the internal `carry`, `sum` and `IO` interface.
-- [`DetectTwoOnes`](./src/main/FSM.scala): A simple finite state machine that uses `ChiselEnum` to represent the states.
-- [`Parity`](./src/main/Parity.scala): A simple circuit that uses an `Enum` (chisel) to represent the states instead of
+- [Adder](./src/main/Adder.scala): A simple N-bit adder circuit, that uses `Array` (scala) class to wrap the 
+    [FullAdder](./src/main/FullAdder.scala)s modules, `Vec` and `Bundle` (chisel) to group together signals needed for the internal `carry`, `sum` and `IO` interface.
+- [DetectTwoOnes](./src/main/FSM.scala): A simple finite state machine that uses `ChiselEnum` to represent the states.
+- [Parity](./src/main/Parity.scala): A simple circuit that uses an `Enum` (chisel) to represent the states instead of
   `ChiselEnum`.
-- [`Functionality`](./src/main/Functionality.scala): A simple circuit that uses different ways to assign values to outputs:
+- [Functionality](./src/main/Functionality.scala): A simple circuit that uses different ways to assign values to outputs:
     - assigning it directly from pure boolean expressions
     - wrapping the boolean expressions into a function
     - wrapping the boolean expression into a `val`
     - using an scala `object`
     - using a scala `class`
-- [`Memory`](./src/main/Memory.scala): A simple module that wraps the `Mem` (chisel) module to implement a simple read/write memory.
-- [`Router`](./src/main/Router.scala): This is the most complex example. It implements a simple router which 
+- [Memory](./src/main/Memory.scala): A simple module that wraps the `Mem` (chisel) module to implement a simple read/write memory.
+- [Router](./src/main/Router.scala): This is the most complex example. It implements a simple router which 
   characteristics are wrapped into objects and classes. It is composed by:
   - A top `Router` module class that instantiates submodules and connect wires together.
   - A `RouterIO` class that defines the IO interface of the router.
@@ -29,7 +29,7 @@ Specifically, the following examples have been selected:
 
 Each example aims to illustrate the representation of a particular aspect supported by Chisel in the testing frameworks. 
 It also shows how this aspect relates to the Chisel source code. Sources and tests are located in the 
-[`src/main`](./src/main) and [`src/chiseltest`](./src/chiseltest) subdirectories, respectively.
+[src/main](./src/main) and [src/chiseltest](./src/chiseltest) subdirectories, respectively.
 
 | Example            | Target                                                                                                                |
 | :----------------- | :-------------------------------------------------------------------------------------------------------------------- |

--- a/examples/tydi-chisel-examples/README.md
+++ b/examples/tydi-chisel-examples/README.md
@@ -14,10 +14,10 @@ The `tydi-chisel-examples` is organized as follows:
 - The [chisel](./chisel) subfolder contains the corresponding Tydi-Chisel code example.
 
 All the examples are related each other and they have an increasing complexity.
-- [`HelloWorldRgb`](./tydi/src/HelloWorldRgb/): A simple example that instantiates two streams of group `Rgb`. It is one of the simplest examples that can be used. It simply connects inputs to outputs.
-- [`PixelConverter`](./tydi/src/PixelConverter/): It extends the `HelloWorldRgb` example by adding more complex data structures that uses `Union`s (similar to software `enum`s) and `Groups` (similar to software `struct`s). It implements a color scale converter from rgb to grayscale and viceversa. Depending on what type is the input stream since can be either rgb or gray it converts its input to the other color-scale. Moreover, it shows how to use tydi-lang templates to define custom and reusable types.
-- [`CLikeStaticArray`](./tydi/src/CLikeStaticArray/): It shows how to use advanced tydi-lang features such as the usage of for loops to instantiate fields in groups/unions/streamlets.
-- [`PipelineSimple`](./tydi/src/PipelineSimple/): A simple streaming pipeline that implements the following simple spark code, where the input is a stream of integers with timestamps attached (`{time: unsigned Integer, value: Integer}`):
+- [HelloWorldRgb](./tydi/src/HelloWorldRgb/): A simple example that instantiates two streams of group `Rgb`. It is one of the simplest examples that can be used. It simply connects inputs to outputs.
+- [PixelConverter](./tydi/src/PixelConverter/): It extends the `HelloWorldRgb` example by adding more complex data structures that uses `Union`s (similar to software `enum`s) and `Groups` (similar to software `struct`s). It implements a color scale converter from rgb to grayscale and viceversa. Depending on what type is the input stream since can be either rgb or gray it converts its input to the other color-scale. Moreover, it shows how to use tydi-lang templates to define custom and reusable types.
+- [CLikeStaticArray](./tydi/src/CLikeStaticArray/): It shows how to use advanced tydi-lang features such as the usage of for loops to instantiate fields in groups/unions/streamlets.
+- [PipelineSimple](./tydi/src/PipelineSimple/): A simple streaming pipeline that implements the following simple spark code, where the input is a stream of integers with timestamps attached (`{time: unsigned Integer, value: Integer}`):
   ```scala
   // Input stream: {timestamp, value}
   // Output stream: {min_value, max_value, sum_value, avg_value}
@@ -32,7 +32,7 @@ All the examples are related each other and they have an increasing complexity.
       .select("min_value", "max_value", "sum_value", "avg_value")
         
   ```
-- [`PipelineNestedGroup`](./tydi/src/PipelineNestedGroup/): It extends the `PipelineSimple` by adding a nested group to the input stream (`{time: unsigned Integer, value: Integer, date: DateTime}`). The `DateTime` can be considered as `{month: unsigned Integer, day: unsigned Integer, year: unsigned Integer, utc: Integer}`. It filters every date that is not in the Amsterdam time zone (UTC+1) and every value that is negative. The corresponding spark code is the following:
+- [PipelineNestedGroup](./tydi/src/PipelineNestedGroup/): It extends the `PipelineSimple` by adding a nested group to the input stream (`{time: unsigned Integer, value: Integer, date: DateTime}`). The `DateTime` can be considered as `{month: unsigned Integer, day: unsigned Integer, year: unsigned Integer, utc: Integer}`. It filters every date that is not in the Amsterdam time zone (UTC+1) and every value that is negative. The corresponding spark code is the following:
   ```scala
   // Input stream: {timestamp, value, date}
   // Output stream: {min_value, max_value, sum_value, avg_value}
@@ -46,7 +46,7 @@ All the examples are related each other and they have an increasing complexity.
           )
       .select("min_value", "max_value", "sum_value", "avg_value")
   ```
-- [`PipelineNestedStreams`](./tydi/src/PipelineNestedStream/): It introduces the concept of nested streams to the `PipelineNestedGroup` example. Specifically, it associates a string (of undefined length) to the input and output streams. A string can be seen as sequence of `char`s and in hardware it can be represented by a stream of `char`s. Since its length is unknown, neither static arrays nor groups can represent it. The corresponding spark code is the following:
+- [PipelineNestedStreams](./tydi/src/PipelineNestedStream/): It introduces the concept of nested streams to the `PipelineNestedGroup` example. Specifically, it associates a string (of undefined length) to the input and output streams. A string can be seen as sequence of `char`s and in hardware it can be represented by a stream of `char`s. Since its length is unknown, neither static arrays nor groups can represent it. The corresponding spark code is the following:
   ```scala
   // Input stream: {timestamp, value, date, string}
   // Output stream: {min_value, max_value, sum_value, avg_value, string}

--- a/results/waveforms/README.md
+++ b/results/waveforms/README.md
@@ -1,4 +1,4 @@
-# An analysis of the waveforms produced by Chisel test benches
+# An analysis of the waveforms produced by Chisel testbenches
 This [page](../chiseltest/) explored advantages and drawbacks of chiseltest[^1]. 
 The framework allows to dump trace files (through `withAnnotations()`) that can be used by waveform viewers to inspect the signals of the circuit under test. 
 


### PR DESCRIPTION
Create an index tree in the home readme in order to simplify the navigation. Create readme for example folder.
Remove code strings that are not needed from readmes.

Close #2 